### PR TITLE
Added a way to specify a custom done button title

### DIFF
--- a/Examples/GMPhotoPicker/ViewController.m
+++ b/Examples/GMPhotoPicker/ViewController.m
@@ -37,6 +37,7 @@
     GMImagePickerController *picker = [[GMImagePickerController alloc] init];
     picker.delegate = self;
     picker.title = @"Custom title";
+    picker.customDoneButtonTitle = @"Done!!!";
     picker.customNavigationBarPrompt = @"Custom helper message!";
     picker.colsInPortrait = 3;
     picker.colsInLandscape = 5;

--- a/GMImagePicker/GMAlbumsViewController.m
+++ b/GMImagePicker/GMAlbumsViewController.m
@@ -67,8 +67,9 @@ static NSString * const CollectionCellReuseIdentifier = @"CollectionCell";
                                         action:@selector(dismiss:)];
     }
     
+    NSString* doneTitle = self.picker.customDoneButtonTitle ? self.picker.customDoneButtonTitle : NSLocalizedStringFromTableInBundle(@"picker.navigation.done-button",  @"GMImagePicker", [NSBundle bundleForClass:GMImagePickerController.class], @"Done");
     self.navigationItem.rightBarButtonItem =
-    [[UIBarButtonItem alloc] initWithTitle:NSLocalizedStringFromTableInBundle(@"picker.navigation.done-button",  @"GMImagePicker", [NSBundle bundleForClass:GMImagePickerController.class], @"Done")
+    [[UIBarButtonItem alloc] initWithTitle:doneTitle
                                      style:UIBarButtonItemStyleDone
                                     target:self.picker
                                     action:@selector(finishPickingAssets:)];

--- a/GMImagePicker/GMGridViewController.m
+++ b/GMImagePicker/GMGridViewController.m
@@ -201,8 +201,9 @@ NSString * const GMGridViewCellIdentifier = @"GMGridViewCellIdentifier";
 
 - (void)setupButtons
 {
+    NSString* doneTitle = self.picker.customDoneButtonTitle ? self.picker.customDoneButtonTitle : NSLocalizedStringFromTableInBundle(@"picker.navigation.done-button",  @"GMImagePicker", [NSBundle bundleForClass:GMImagePickerController.class], @"Done");
     self.navigationItem.rightBarButtonItem =
-    [[UIBarButtonItem alloc] initWithTitle:NSLocalizedStringFromTableInBundle(@"picker.navigation.done-button",  @"GMImagePicker", [NSBundle bundleForClass:GMImagePickerController.class], @"Done")
+    [[UIBarButtonItem alloc] initWithTitle:doneTitle
                                      style:UIBarButtonItemStyleDone
                                     target:self.picker
                                     action:@selector(finishPickingAssets:)];

--- a/GMImagePicker/GMImagePickerController.h
+++ b/GMImagePicker/GMImagePickerController.h
@@ -65,6 +65,11 @@ static CGSize const kPopoverContentSize = {480, 720};
 @property (nonatomic) NSString* customNavigationBarPrompt;
 
 /**
+ *  If set, it overrides the title for the done button
+ */
+@property (nonatomic) NSString* customDoneButtonTitle;
+
+/**
  *  Determines whether or not a toolbar with info about user selection is shown.
  *  The InfoToolbar is visible by default.
  */


### PR DESCRIPTION
I want the "Done" button to say "Import" instead, so I needed to be able to add a way to customize the title of the "Done" button. If customDoneButtonTitle is non-nil, the done button title will be set to that.