### PR TITLE
Fix Transparency for Navigation and Toolbar

### DIFF
--- a/Examples/GMPhotoPicker/Info.plist
+++ b/Examples/GMPhotoPicker/Info.plist
@@ -22,6 +22,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Access media in Photos</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Examples/GMPhotoPicker/ViewController.m
+++ b/Examples/GMPhotoPicker/ViewController.m
@@ -59,10 +59,12 @@
 
 //    picker.pickerBackgroundColor = [UIColor blackColor];
 //    picker.pickerTextColor = [UIColor whiteColor];
-//    picker.toolbarBarTintColor = [UIColor darkGrayColor];
+//    picker.toolbarBackgroundColor = [UIColor darkGrayColor];
+//    picker.toolbarBarTintColor = [UIColor blackColor];
 //    picker.toolbarTextColor = [UIColor whiteColor];
 //    picker.toolbarTintColor = [UIColor redColor];
-//    picker.navigationBarBackgroundColor = [UIColor blackColor];
+//    picker.navigationBarBackgroundColor = [UIColor darkGrayColor];
+//    picker.navigationBarBarTintColor = [UIColor blackColor];
 //    picker.navigationBarTextColor = [UIColor whiteColor];
 //    picker.navigationBarTintColor = [UIColor redColor];
 //    picker.pickerFontName = @"Verdana";

--- a/GMImagePicker/GMAlbumsViewController.m
+++ b/GMImagePicker/GMAlbumsViewController.m
@@ -345,7 +345,7 @@ static NSString * const CollectionCellReuseIdentifier = @"CollectionCell";
 {
     UITableViewHeaderFooterView *header = (UITableViewHeaderFooterView *)view;
     header.contentView.backgroundColor = [UIColor clearColor];
-    header.backgroundView.backgroundColor = [UIColor clearColor];
+    header.backgroundView.backgroundColor = self.picker.pickerBackgroundColor;
 
     // Default is a bold font, but keep this styled as a normal font
     header.textLabel.font = [UIFont fontWithName:self.picker.pickerFontName size:self.picker.pickerFontNormalSize];

--- a/GMImagePicker/GMAlbumsViewController.m
+++ b/GMImagePicker/GMAlbumsViewController.m
@@ -104,11 +104,6 @@ static NSString * const CollectionCellReuseIdentifier = @"CollectionCell";
     
     // Register for changes
     [[PHPhotoLibrary sharedPhotoLibrary] registerChangeObserver:self];
-    
-    if ([self respondsToSelector:@selector(setEdgesForExtendedLayout:)])
-    {
-        self.edgesForExtendedLayout = UIRectEdgeNone;
-    }
 }
 
 - (void)dealloc

--- a/GMImagePicker/GMGridViewController.m
+++ b/GMImagePicker/GMGridViewController.m
@@ -128,11 +128,6 @@ NSString * const GMGridViewCellIdentifier = @"GMGridViewCellIdentifier";
     self.imageManager = [[PHCachingImageManager alloc] init];
     [self resetCachedAssets];
     [[PHPhotoLibrary sharedPhotoLibrary] registerChangeObserver:self];
-    
-    if ([self respondsToSelector:@selector(setEdgesForExtendedLayout:)])
-    {
-        self.edgesForExtendedLayout = UIRectEdgeNone;
-    }
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/GMImagePicker/GMImagePickerController.h
+++ b/GMImagePicker/GMImagePickerController.h
@@ -137,10 +137,12 @@ static CGSize const kPopoverContentSize = {480, 720};
  *
  * - pickerBackgroundColor: The colour for all backgrounds; behind the table and cells. Defaults to [UIColor whiteColor]
  * - pickerTextColor: The color for text in the views. This needs to work with pickerBackgroundColor! Default of darkTextColor
+ * - toolbarBackgroundColor: The background color of the toolbar. Defaults to nil.
  * - toolbarBarTintColor: The color for the background tint of the toolbar
  * - toolbarTextColor: The color of the text on the toolbar
  * - toolbarTintColor: The tint colour used for any buttons on the toolbar
  * - navigationBarBackgroundColor: The background of the navigation bar. Defaults to [UIColor whiteColor]
+ * - navigationBarBarTintColor: The color for the background tint of the navigation bar. Defaults to nil.
  * - navigationBarTextColor: The color for the text in the navigation bar. Defaults to [UIColor darkTextColor]
  * - navigationBarTintColor: The tint color used for any buttons on the navigation Bar
  * - pickerFontName: The font to use everywhere. Defaults to HelveticaNeue. It is advised if you set this to check, and possibly set, appropriately the custom font sizes. For font information, check http://www.iosfonts.com/
@@ -152,10 +154,12 @@ static CGSize const kPopoverContentSize = {480, 720};
  */
 @property (nonatomic, strong) UIColor *pickerBackgroundColor;
 @property (nonatomic, strong) UIColor *pickerTextColor;
+@property (nonatomic, strong) UIColor *toolbarBackgroundColor;
 @property (nonatomic, strong) UIColor *toolbarBarTintColor;
 @property (nonatomic, strong) UIColor *toolbarTextColor;
 @property (nonatomic, strong) UIColor *toolbarTintColor;
 @property (nonatomic, strong) UIColor *navigationBarBackgroundColor;
+@property (nonatomic, strong) UIColor *navigationBarBarTintColor;
 @property (nonatomic, strong) UIColor *navigationBarTextColor;
 @property (nonatomic, strong) UIColor *navigationBarTintColor;
 @property (nonatomic, strong) NSString *pickerFontName;

--- a/GMImagePicker/GMImagePickerController.h
+++ b/GMImagePicker/GMImagePickerController.h
@@ -138,10 +138,10 @@ static CGSize const kPopoverContentSize = {480, 720};
  * - pickerBackgroundColor: The colour for all backgrounds; behind the table and cells. Defaults to [UIColor whiteColor]
  * - pickerTextColor: The color for text in the views. This needs to work with pickerBackgroundColor! Default of darkTextColor
  * - toolbarBackgroundColor: The background color of the toolbar. Defaults to nil.
- * - toolbarBarTintColor: The color for the background tint of the toolbar
+ * - toolbarBarTintColor: The color for the background tint of the toolbar. Defaults to nil.
  * - toolbarTextColor: The color of the text on the toolbar
  * - toolbarTintColor: The tint colour used for any buttons on the toolbar
- * - navigationBarBackgroundColor: The background of the navigation bar. Defaults to [UIColor whiteColor]
+ * - navigationBarBackgroundColor: The background of the navigation bar. Defaults to nil.
  * - navigationBarBarTintColor: The color for the background tint of the navigation bar. Defaults to nil.
  * - navigationBarTextColor: The color for the text in the navigation bar. Defaults to [UIColor darkTextColor]
  * - navigationBarTintColor: The tint color used for any buttons on the navigation Bar

--- a/GMImagePicker/GMImagePickerController.m
+++ b/GMImagePicker/GMImagePickerController.m
@@ -86,7 +86,6 @@
     _navigationController.toolbar.translucent = YES;
     _navigationController.toolbar.barTintColor = _toolbarBarTintColor;
     _navigationController.toolbar.tintColor = _toolbarTintColor;
-    [(UIView*)[_navigationController.toolbar.subviews objectAtIndex:0] setAlpha:0.75f];  // URGH - I know!
     
     _navigationController.navigationBar.backgroundColor = _navigationBarBackgroundColor;
     _navigationController.navigationBar.tintColor = _navigationBarTintColor;

--- a/GMImagePicker/GMImagePickerController.m
+++ b/GMImagePicker/GMImagePickerController.m
@@ -115,8 +115,6 @@
     _navigationController.delegate = self;
     
     _navigationController.navigationBar.translucent = YES;
-    [_navigationController.navigationBar setBackgroundImage:[UIImage new] forBarMetrics:UIBarMetricsDefault];
-    _navigationController.navigationBar.shadowImage = [UIImage new];
     
     [_navigationController willMoveToParentViewController:self];
     [_navigationController.view setFrame:self.view.frame];

--- a/GMImagePicker/GMImagePickerController.m
+++ b/GMImagePicker/GMImagePickerController.m
@@ -60,12 +60,10 @@
         _pickerBoldFontName = @"HelveticaNeue-Bold";
         _pickerFontNormalSize = 14.0f;
         _pickerFontHeaderSize = 17.0f;
-        
-        _navigationBarBackgroundColor = [UIColor whiteColor];
+       
         _navigationBarTextColor = [UIColor darkTextColor];
         _navigationBarTintColor = [UIColor darkTextColor];
         
-        _toolbarBarTintColor = [UIColor whiteColor];
         _toolbarTextColor = [UIColor darkTextColor];
         _toolbarTintColor = [UIColor darkTextColor];
         

--- a/GMImagePicker/GMImagePickerController.m
+++ b/GMImagePicker/GMImagePickerController.m
@@ -84,11 +84,14 @@
     self.view.backgroundColor = _pickerBackgroundColor;
 
     _navigationController.toolbar.translucent = YES;
+    _navigationController.toolbar.backgroundColor = _toolbarBackgroundColor;
     _navigationController.toolbar.barTintColor = _toolbarBarTintColor;
     _navigationController.toolbar.tintColor = _toolbarTintColor;
     
     _navigationController.navigationBar.backgroundColor = _navigationBarBackgroundColor;
+    _navigationController.navigationBar.barTintColor = _navigationBarBarTintColor;
     _navigationController.navigationBar.tintColor = _navigationBarTintColor;
+   
     NSDictionary *attributes;
     if (_useCustomFontForNavigationBar) {
         attributes = @{NSForegroundColorAttributeName : _navigationBarTextColor,


### PR DESCRIPTION
- Fixes the iOS 10 permission crash in the Example project
- Fixes the iOS 10 crash caused by trying accessing an empty array
- Sets the transparency to work let Apple's default transparency
- Added new customization options to better provide support similar to Apple toolbar / navigation bars.
- Removed the default tint / background colors to match Apple's default of nil.
- Fixed an additional issue where the album view's header did not have a background so the text would just overlap the top of whatever was under it while scrolling. 